### PR TITLE
Feature/threshold config

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -62,6 +62,18 @@ variable "target_group_health_response" {
   default     = 200
 }
 
+variable "target_group_gc_healthy_threshold" {
+  description = "Number of consecutive health checks successes required before considering an unhealthy target healthy. Default is 3"
+  type        = number
+  default     = 3
+}
+
+variable "target_group_gc_unhealthy_threshold" {
+  description = "Number of consecutive health check failures required before considering the target unhealthy. Default is 3"
+  type        = number
+  default     = 3
+}
+
 variable "input_tags" {
   description = "Map of tags to apply to resources"
   type        = map(string)

--- a/-inputs.tf
+++ b/-inputs.tf
@@ -62,13 +62,13 @@ variable "target_group_health_response" {
   default     = 200
 }
 
-variable "target_group_gc_healthy_threshold" {
+variable "target_group_hc_healthy_threshold" {
   description = "Number of consecutive health checks successes required before considering an unhealthy target healthy. Default is 3"
   type        = number
   default     = 3
 }
 
-variable "target_group_gc_unhealthy_threshold" {
+variable "target_group_hc_unhealthy_threshold" {
   description = "Number of consecutive health check failures required before considering the target unhealthy. Default is 3"
   type        = number
   default     = 3

--- a/main.tf
+++ b/main.tf
@@ -17,13 +17,15 @@ resource "aws_lb_target_group" "this" {
 
   target_type = var.target_group_type
   health_check {
-    enabled  = true
-    protocol = coalesce(var.target_group_health_protocol, var.target_group_protocol)
-    path     = var.target_group_health_path
-    interval = var.target_group_health_interval
-    matcher  = var.target_group_health_response
-    port     = var.target_group_health_port
-    timeout  = var.target_group_health_timeout
+    enabled             = true
+    protocol            = coalesce(var.target_group_health_protocol, var.target_group_protocol)
+    path                = var.target_group_health_path
+    interval            = var.target_group_health_interval
+    matcher             = var.target_group_health_response
+    port                = var.target_group_health_port
+    timeout             = var.target_group_health_timeout
+    healthy_threshold   = var.target_group_hc_healthy_threshold
+    unhealthy_threshold = var.target_group_hc_unhealthy_threshold
   }
 
   dynamic "stickiness" {


### PR DESCRIPTION
- Enabling configuration of thresholds in health checks (healthy and unhealthy)
- Giving same default values as Terraform does to not broke previous versions (if they don't have any version selected)