### PR TITLE
Feature: add protocol_version support to allow use of HTTP/2 and gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ module "lb-target-group" {
 | <a name="input_target_group_name_prefix"></a> [target\_group\_name\_prefix](#input\_target\_group\_name\_prefix) | name prefix (pre-random) of target group to be created | `string` | n/a | yes |
 | <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | Port configuration for LB Target group | `number` | `443` | no |
 | <a name="input_target_group_protocol"></a> [target\_group\_protocol](#input\_target\_group\_protocol) | Protocol configuration for LB Target group | `string` | `"HTTPS"` | no |
+| <a name="input_target_group_protocol_version"></a> [target\_group\_protocol\_version](#input\_target\_group\_protocol\_version) | Protocol version to send to targets (Optional, Forces new resource). Only used when target\_group\_protocol is HTTP/HTTPS | `string` | `"HTTP1"` | no |
 | <a name="input_target_group_type"></a> [target\_group\_type](#input\_target\_group\_type) | Target type (ip/instance, lambda is not supported by this module) | `string` | `"ip"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of VPC which the resource should be created in | `string` | n/a | yes |
 

--- a/inputs.tf
+++ b/inputs.tf
@@ -26,6 +26,11 @@ variable "target_group_protocol" {
   default     = "HTTPS"
 }
 
+variable "target_group_protocol_version" {
+  description = "Protocol version to send to targets (Optional, Forces new resource). Only used when target_group_protocol is HTTP/HTTPS"
+  default     = "HTTP1"
+}
+
 variable "target_group_health_protocol" {
   description = "Override protocol for health check, otherwise this will match traffic protocol"
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -10,10 +10,11 @@ resource "random_id" "this" {
 }
 
 resource "aws_lb_target_group" "this" {
-  name     = "${var.target_group_name_prefix}-${random_id.this.hex}"
-  port     = var.target_group_port
-  protocol = var.target_group_protocol
-  vpc_id   = var.vpc_id
+  name             = "${var.target_group_name_prefix}-${random_id.this.hex}"
+  port             = var.target_group_port
+  protocol         = var.target_group_protocol
+  protocol_version = length(regexall("^HTTP+", var.target_group_protocol)) > 0 ? var.target_group_protocol_version : null
+  vpc_id           = var.vpc_id
 
   target_type = var.target_group_type
   health_check {


### PR DESCRIPTION
## Change description

This PR introduces [protocol_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#protocol_version) support to aws_lb_target_group to allow the use of HTTP/2 and gRPC in addition to the default, HTTP/1

* new target group resources behave as you would expect them to
* existing target groups are not modified by this feature

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
